### PR TITLE
Correct type miss match

### DIFF
--- a/src/kinematics/src/CustomPower.cpp
+++ b/src/kinematics/src/CustomPower.cpp
@@ -99,7 +99,7 @@ adouble CustomPower::Loss(adouble E, double width, int points)
         }
         e += (R1 + 0.5*(R2 + R3) + R4)/6.0;
     }
-    e[e<0] = 0.0;
+    e[e<0.0] = 0.0;
     e[e!=e] = 0.0;
     return e;
 }

--- a/src/kinematics/src/Ziegler1985.cpp
+++ b/src/kinematics/src/Ziegler1985.cpp
@@ -106,7 +106,7 @@ adouble Ziegler1985::Loss(adouble E, int points)
         }
         e += (R1 + 0.5*(R2 + R3) + R4)/6.0;
     }
-    e[e<0] = 0.0;
+    e[e<0.0] = 0.0;
     e[e!=e] = 0.0;
     return e/1e3;
 }
@@ -125,7 +125,7 @@ adouble Ziegler1985::Loss(adouble E, double width, int points)
         }
         e += (R1 + 0.5*(R2 + R3) + R4)/6.0;
     }
-    e[e<0] = 0.0;
+    e[e<0.0] = 0.0;
     e[e!=e] = 0.0;
     return e/1e3;
 }


### PR DESCRIPTION
Was unable to compile on Arch Linux with gcc 7.2.1. This was caused by a type miss match between double and int.